### PR TITLE
Fix bug to use current hostname!

### DIFF
--- a/web/clips.js
+++ b/web/clips.js
@@ -79,7 +79,7 @@ async function SetClip( visible, id = "" ) {
 			}, clipInfo.duration * 1000 );
 		}
 		var clip = document.querySelector( "#fluffy-clip" );
-		clip.setAttribute( "src", "https://clips.twitch.tv/embed?parent=instafluff.tv&parent=www.instafluff.tv&tt_medium=clips_api&tt_content=embed&autoplay=true&clip=" + id );
+		clip.setAttribute( "src", "https://clips.twitch.tv/embed?parent=" + window.location.hostname + "&tt_medium=clips_api&tt_content=embed&autoplay=true&clip=" + id );
 		clip.style.display = "block";
 		showCount--;
 	}


### PR DESCRIPTION
Automatically get the hostname without portnumber or anything else. just the hostname `www.instafluff.tv`, `instafluff.tv`, `localhost` etc